### PR TITLE
feat: Add support check for arm64 architecture on Linux distributions

### DIFF
--- a/02-linux-installqt6.sh
+++ b/02-linux-installqt6.sh
@@ -108,6 +108,35 @@ if [[ "$(arch)" = "x86_64" ]] ; then
 else
 
     # arm64
+    # According to Qt documentation (https://doc.qt.io/qt-6/linux.html),
+    # arm64 is only supported on specific Linux distributions:
+    # - Ubuntu 24.04 (GCC 13.x)
+    # - Debian 11.6 (GCC 10)
+    # - Debian 12 (GCC 12)
+    
+    ARM64_SUPPORTED=false
+    
+    if [[ "$LINUX_NAME" == *"Ubuntu"* ]]; then
+        if [[ "$LINUX_VERSION" == "24.04" ]]; then
+            ARM64_SUPPORTED=true
+            echo "arm64: Ubuntu 24.04 is supported for Qt6 arm64 build."
+        fi
+    elif [[ "$LINUX_NAME" == *"Debian"* ]]; then
+        if [[ "$LINUX_VERSION" == "11.6" || "$LINUX_VERSION" == "11" || "$LINUX_VERSION" == "12" ]]; then
+            ARM64_SUPPORTED=true
+            echo "arm64: Debian $LINUX_VERSION is supported for Qt6 arm64 build."
+        fi
+    fi
+    
+    if [[ "$ARM64_SUPPORTED" == false ]]; then
+        echo "ERROR: arm64 architecture is not supported on $LINUX_NAME $LINUX_VERSION"
+        echo "According to Qt documentation, arm64 is only supported on:"
+        echo "  - Ubuntu 24.04 (GCC 13.x)"
+        echo "  - Debian 11.6 (GCC 10)"
+        echo "  - Debian 12 (GCC 12)"
+        echo "Please use a supported distribution or x86_64 architecture."
+        exit 1
+    fi
 
     $INSTALL_DIR/bin/cmake --build . --config RelWithDebInfo --target ext_qt6 -- -j1
 


### PR DESCRIPTION
According to Qt documentation (https://doc.qt.io/qt-6/linux.html),

According to the official Qt documentation, added validation for arm64 architecture support on specific Linux distributions. The script now checks for supported distributions such as Ubuntu 24.04 and Debian 11.6/12, and will display an error message and exit the installation process if the requirements are not met.


Arm64 supported Linux
  - Ubuntu 24.04 (GCC 13.x)
 - Debian 11.6 (GCC 10)
 - Debian 12 (GCC 12)